### PR TITLE
Updating config environment variable to pick host

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -193,7 +193,7 @@ class Swagger(object):
         return not_none(specs)
 
     def get_host(self):
-        hostname = current_app.config.get('SERVER_NAME', None) or None
+        hostname = current_app.config.get('SWAGGER_HOST', None) or None
         if hostname and self.api.blueprint and self.api.blueprint.subdomain:
             hostname = '.'.join((self.api.blueprint.subdomain, hostname))
         return hostname


### PR DESCRIPTION
Currently host is picked from SERVER_NAME which is also being used by flask to pick host name. However it is not solving the case where 
1) documentation server and actual api server are different 
2) api are routed via api-gateway which authenticate the request and then redirect to api server.
I would like to set  different server (other than where swagger documentation is hosted) in swagger 'host' parameter, which will be used to call APIs with on 'try now'.

e.g. https://myserver/api/v1 -> swagger page
       Sample API: /welcome
Call on "try now" -> https://myapigateway/api/v1/welcome which on successful authentication redirect request to https:myserver/api/v1/welcome
